### PR TITLE
chore(release): bump tx3-sdk to 0.12.0

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tx3-sdk"
-version = "0.11.0"
+version = "0.12.0"
 description = "Tx3 SDK for Python"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/sdk/src/tx3_sdk/__init__.py
+++ b/sdk/src/tx3_sdk/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "coerce_arg",
 ]
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
## Summary

Bumps `tx3-sdk` to **0.12.0** to align with the fleet's 0.12 release train. The unified-builder port that merged in [#13](https://github.com/tx3-lang/python-sdk/pull/13) is a breaking change and per [release-policy.md](https://github.com/tx3-lang/toolchain/blob/main/sdks/sdk-spec/release-policy.md) any MINOR/MAJOR change MUST be coordinated across all SDKs (rust-sdk's workspace already declares 0.12.0).

Bumps both `pyproject.toml` and the runtime `__version__` constant in `tx3_sdk/__init__.py`.

After this lands, a `v0.12.0` tag will be pushed to trigger the release workflow → publish to PyPI.

## Test plan

- [x] Two-line version bump, no code change. CI covers everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)