### PR TITLE
feat(codegen): render named types for protocol custom types

### DIFF
--- a/.trix/client-lib/__init__.py.hbs
+++ b/.trix/client-lib/__init__.py.hbs
@@ -29,6 +29,11 @@ ENVIRONMENT_SCHEMA: dict[str, Any] = json.loads(
 )
 
 {{/if}}
+{{#if tii.components.schemas}}
+# Named types for the protocol's custom (record / variant) types.
+{{{componentTypes tii.components.schemas "python"}}}
+
+{{/if}}
 {{#each tii.transactions}}
 {{constantCase @key}}_TIR = TirEnvelope(
     content="{{tir.content}}",


### PR DESCRIPTION
## What

Declare a named type per `components.schemas` entry in the generated client:
a full struct/interface/dataclass for records, and a permissive named alias
for variants (pending the variant arg encoder).

Driven by the new `componentTypes` helper in `tx3c codegen`.

Pairs with `tx3-lang/tx3` (emitter + codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
