### PR TITLE
chore: release 0.13.0

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tx3-sdk"
-version = "0.12.0"
+version = "0.13.0"
 description = "Tx3 SDK for Python"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Release-prep for the coordinated **0.13.0** SDK fleet train.

All four SDKs carry the unreleased breaking `feat(tii)!: interpret the full complex param-type model` change on top of the already-tagged `v0.12.0`. Per `sdk-spec/versioning.md` + `release-policy.md`, a breaking TII change forces at minimum a coordinated minor bump across the fleet, and `0.12.0` can't be reused — so the train moves to `0.13.0`.

This PR bumps the package version and the `.trix/client-lib` codegen template's pinned SDK requirement **in the same commit** (required by `sdk-spec/codegen/versioning.md` — the template requirement must not get ahead of the source version).

Merging this is the prerequisite for tagging the release (`release.yml` validates `tag == manifest version`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)